### PR TITLE
Make the openstack-server great again

### DIFF
--- a/add_authorized_key.yml
+++ b/add_authorized_key.yml
@@ -1,0 +1,11 @@
+---
+- name: A one time action to all the hosts in the inventory
+  hosts: all
+  vars:
+    public_key: "{{ lookup('file', ansible_public_key_file) }}"
+  tasks:
+    # Add the public key to the authorized key file for ansible_user
+    - name: Adding the public key to the authorized_key file
+      authorized_key:
+        user: "{{ ansible_user }}"
+        key: "{{ public_key }}"

--- a/create_server_openstack.yml
+++ b/create_server_openstack.yml
@@ -24,7 +24,7 @@
       - { name: node_average, vcpu: 4, memory: 16384, disk: 80 }
     openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
     openstack_project: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(ansible_user_dir ~ '/overcloudrc', true) }}"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/openstackrc', true) }}"
     private_key_path: "{{ lookup('env', 'private_key_path') | default(ansible_private_key_file, true) }}"
     public_key_path: "{{ lookup('env', 'public_key_path') | default(ansible_public_key_file, true) }}"
     public_network_name: "{{ lookup('env', 'public_network_name') | default('public_network', true) }}"
@@ -33,7 +33,7 @@
         { cores: 1444, gigabytes: 50000, instances: 550, ports: 10000, ram: 5865472, volumes: 50000 }
     router_name: "{{ lookup('env', 'router_name') | default('ci_router', true) }}"
     security_group_name: "{{ lookup('env', 'security_group_name') | default('ci_security_group', true) }}"
-    server_flavor: "{{ lookup('env', 'server_flavor') | default('m1.medium', true) }}"
+    server_flavor: "{{ lookup('env', 'server_flavor') | default('node_small', true) }}"
     server_image: "{{ lookup('env', 'server_image') | default('ocp-3.7-rhel', true) }}"
     server_name: "{{ lookup('env', 'server_name') | default('ansible-host', true) }}"
     subnet_name: "{{ lookup('env', 'subnet_name') | default('ci_subnet', true) }}"

--- a/create_server_openstack.yml
+++ b/create_server_openstack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set up one virtual machine server in a new OpenStack environment
-  hosts: openstack-server
+  hosts: localhost
   vars:
     ec2_flavors:
       # https://aws.amazon.com/ec2/previous-generation/
@@ -13,7 +13,6 @@
       - { name: m4.2xlarge, vcpu: 8, memory: 32768, disk: 200 }
       - { name: m4.4xlarge, vcpu: 16, memory: 65536, disk: 300 }
       - { name: m4.10xlarge, vcpu: 40, memory: 163840, disk: 500 }
-    install_directory: "{{ ansible_user_dir }}/scale-ci"
     keypair_name: "{{ lookup('env', 'keypair_name') | default('ci_keypair', true) }}"
     network_name: "{{ lookup('env', 'network_name') | default('ci_network', true) }}"
     openshift_flavors:
@@ -23,11 +22,11 @@
       - { name: master_etcd, vcpu: 64, memory: 245760, disk: 512 }
       - { name: node_small, vcpu: 1, memory: 2048, disk: 80 }
       - { name: node_average, vcpu: 4, memory: 16384, disk: 80 }
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(install_directory ~ '/virtualenv/bin/openstack', true) }}"
+    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
     openstack_project: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
     openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(ansible_user_dir ~ '/overcloudrc', true) }}"
-    private_key_path: "{{ lookup('env', 'private_key_path') | default(install_directory ~ '/key.private', true) }}"
-    public_key_path: "{{ lookup('env', 'public_key_path') | default(install_directory ~ '/key.public', true) }}"
+    private_key_path: "{{ lookup('env', 'private_key_path') | default(ansible_private_key_file, true) }}"
+    public_key_path: "{{ lookup('env', 'public_key_path') | default(ansible_public_key_file, true) }}"
     public_network_name: "{{ lookup('env', 'public_network_name') | default('public_network', true) }}"
     public_subnet_name: "{{ lookup('env', 'public_subnet_name') | default('public_subnet', true) }}"
     quotas:
@@ -48,7 +47,10 @@
       - { name: n1-standard-16, vcpu: 16, memory: 60000, disk: 128 }
       - { name: n1-standard-32, vcpu: 32, memory: 120000, disk: 256 }
       - { name: n1-standard-64, vcpu: 64, memory: 240000, disk: 256 }
-
+    virtualenv_directory: "{{ playbook_dir }}/virtualenv"
+  roles:
+    # Install the OpenStack client on this server.
+    - "openstack-client"
   tasks:
     # Check for the existance of the OpenStack client.
     - name: Checking for the OpenStack client

--- a/create_server_openstack.yml
+++ b/create_server_openstack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set up one virtual machine server in a new OpenStack environment
-  hosts: localhost
+  hosts: openstack-server
   vars:
     ec2_flavors:
       # https://aws.amazon.com/ec2/previous-generation/
@@ -13,8 +13,10 @@
       - { name: m4.2xlarge, vcpu: 8, memory: 32768, disk: 200 }
       - { name: m4.4xlarge, vcpu: 16, memory: 65536, disk: 300 }
       - { name: m4.10xlarge, vcpu: 40, memory: 163840, disk: 500 }
+    install_directory: "{{ ansible_user_dir }}/scale-ci"
     keypair_name: "{{ lookup('env', 'keypair_name') | default('ci_keypair', true) }}"
     network_name: "{{ lookup('env', 'network_name') | default('ci_network', true) }}"
+    ocp_major_minor: "{{ lookup('env', 'ocp_major_minor') | default('3.7', true) }}"
     openshift_flavors:
       - { name: container_storage, vcpu: 16, memory: 65536, disk: 128 }
       - { name: load_balancer, vcpu: 4, memory: 16384, disk: 128 }
@@ -22,11 +24,11 @@
       - { name: master_etcd, vcpu: 64, memory: 245760, disk: 512 }
       - { name: node_small, vcpu: 1, memory: 2048, disk: 80 }
       - { name: node_average, vcpu: 4, memory: 16384, disk: 80 }
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
+    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default('/usr/bin/openstack', true) }}"
     openstack_project: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/openstackrc', true) }}"
-    private_key_path: "{{ lookup('env', 'private_key_path') | default(ansible_private_key_file, true) }}"
-    public_key_path: "{{ lookup('env', 'public_key_path') | default(ansible_public_key_file, true) }}"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(ansible_user_dir ~ '/overcloudrc', true) }}"
+    private_key_path: "{{ lookup('env', 'private_key_path') | default(install_directory ~ '/key.private', true) }}"
+    public_key_path: "{{ lookup('env', 'public_key_path') | default(install_directory ~ '/key.public', true) }}"
     public_network_name: "{{ lookup('env', 'public_network_name') | default('public_network', true) }}"
     public_subnet_name: "{{ lookup('env', 'public_subnet_name') | default('public_subnet', true) }}"
     quotas:
@@ -47,10 +49,6 @@
       - { name: n1-standard-16, vcpu: 16, memory: 60000, disk: 128 }
       - { name: n1-standard-32, vcpu: 32, memory: 120000, disk: 256 }
       - { name: n1-standard-64, vcpu: 64, memory: 240000, disk: 256 }
-    virtualenv_directory: "{{ playbook_dir }}/virtualenv"
-  roles:
-    # Install the OpenStack client on this server.
-    - "openstack-client"
   tasks:
     # Check for the existance of the OpenStack client.
     - name: Checking for the OpenStack client
@@ -174,6 +172,38 @@
         - volumes
       # Only set quotas when the project is defined.
       when: openstack_project != ""
+
+    # Find the images to upload.
+    - name: Searching for the ocp-{{ ocp_major_minor }} files in {{ install_directory }}
+      find:
+        paths: "{{ install_directory }}"
+        patterns: "([0-9]+-[0-9]+-[0-9]+)-ocp-({{ ocp_major_minor }}.+)-.+qcow2"
+        use_regex: yes
+        recurse: true
+      register: images
+
+    # Delete any images with the same name as the one we are about to upload.
+    - name: Deleting the existing images in OpenStack
+      shell: "{{ openstack }} image delete ocp-{{ ocp_major_minor }}-{{ item }}"
+      with_items: "{{ [ 'atomic', 'rhel' ] }}"
+      # Do not fail if here is no image to delete.
+      ignore_errors: true
+
+    # Upload the images to Glance.
+    - name: Uploading the images to OpenStack
+      shell: "{{ openstack }} image create --disk-format qcow2 --container-format bare --file {{ item['path'] }} ocp-{{ ocp_major_minor }}-{{ ('atomic' in item['path'])|ternary('atomic','rhel') }} --format value -c id"
+      with_items: "{{ images['files'] }}"
+      register: create_result
+      # Retry up to 3 times looking for a successful return code.
+      until: create_result['rc'] == 0
+      retries: 3
+      delay: 5
+      ignore_errors: yes
+
+    # Add metadata to the OpenStack about the image.
+    - name: Adding metadata about the image
+      shell: "{{ openstack }} image set --property file_name={{ item['path']|basename }} --property directory={{ item['path']|dirname }} ocp-{{ ocp_major_minor }}-{{ ('atomic' in item['path'])|ternary('atomic','rhel') }}"
+      with_items: "{{ images['files'] }}"
 
     # Create a VM instance with the flavor, image, group, keypair and network.
     - name: Creating a server instance {{ server_name }}

--- a/delete_server_openstack.yml
+++ b/delete_server_openstack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Steps to clean up an OpenStack environment
-  hosts: openstack-server
+  hosts: localhost
   vars:
     keypair_name: "{{ lookup('env', 'keypair_name') | default('ci_keypair', true) }}"
     network_name: "{{ lookup('env', 'network_name') | default('ci_network', true) }}"

--- a/delete_server_openstack.yml
+++ b/delete_server_openstack.yml
@@ -1,11 +1,12 @@
 ---
 - name: Steps to clean up an OpenStack environment
-  hosts: localhost
+  hosts: openstack-server
   vars:
+    install_directory: "{{ ansible_user_dir}}/scale-ci"
     keypair_name: "{{ lookup('env', 'keypair_name') | default('ci_keypair', true) }}"
     network_name: "{{ lookup('env', 'network_name') | default('ci_network', true) }}"
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/openstackrc', true) }}"
+    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default('/usr/bin/openstack', true) }}"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(ansible_user_dir ~ '/overcloudrc', true) }}"
     router_name: "{{ lookup('env', 'router_name') | default('ci_router', true) }}"
     security_group_name: "{{ lookup('env', 'security_group_name') | default('ci_security_group', true) }}"
     server_name: "{{ lookup('env', 'server_name') | default('ansible-host', true) }}"

--- a/delete_server_openstack.yml
+++ b/delete_server_openstack.yml
@@ -2,16 +2,14 @@
 - name: Steps to clean up an OpenStack environment
   hosts: openstack-server
   vars:
-    install_directory: "{{ ansible_user_dir}}/scale-ci"
     keypair_name: "{{ lookup('env', 'keypair_name') | default('ci_keypair', true) }}"
     network_name: "{{ lookup('env', 'network_name') | default('ci_network', true) }}"
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(install_directory ~ '/virtualenv/bin/openstack', true) }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default('~/overcloudrc', true) }}"
+    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/openstackrc', true) }}"
     router_name: "{{ lookup('env', 'router_name') | default('ci_router', true) }}"
     security_group_name: "{{ lookup('env', 'security_group_name') | default('ci_security_group', true) }}"
     server_name: "{{ lookup('env', 'server_name') | default('ansible-host', true) }}"
     subnet_name: "{{ lookup('env', 'subnet_name') | default('ci_subnet', true) }}"
-
   vars_prompt:
     - name: "delete_flavors"
       prompt: "Delete the flavors? "
@@ -21,7 +19,6 @@
       prompt: "Delete the images? "
       default: no
       private: no
-
   tasks:
     # Check for the existance of the OpenStack client.
     - name: Checking for the OpenStack client

--- a/find_and_prepare_images.yml
+++ b/find_and_prepare_images.yml
@@ -11,16 +11,13 @@
     image_directory: image_builder/qcow_images
     ocp_major_minor: "{{ lookup('env', 'ocp_major_minor') | default('3.7', true) }}"
     openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(install_directory ~ '/virtualenv/bin/openstack', true) }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(install_directory ~ '/overcloudrc', true) }}"
     # A string path relative to the user's home directory to the rhel image.
     rhel_image: "{{ lookup('env', 'rhel_image') }}"
     virtualenv_directory: "{{ install_directory }}/virtualenv"
     web_root: /var/www/html
-
   roles:
-    # Install general prerequisites for OpenStack and Ansible.
-    - general-prerequisites
-
+    # Install the OpenStack client on this server.
+    - "openstack-client"
   tasks:
     # Get all the atomic files matching the pattern.
     - name: Searching for the ocp-{{ ocp_major_minor }} files in {{ image_directory }}/atomic
@@ -147,13 +144,13 @@
     # Copy the rc file to the image server.
     - name: Copying the OpenStack rc file to the image server
       copy:
-        src: "openstackrc"
-        dest: "{{ openstack_rc }}"
+        src: "{{ playbook_dir }}/openstackrc"
+        dest: "{{ install_directory }}/openstackrc"
 
     # The openstack variable includes the rc file and the path to the OpenStack client.
     - name: Setting openstack variable to source the rc file and contain path to client
       set_fact:
-        openstack: "source {{ openstack_rc }}; {{ openstack_location }}"
+        openstack: "source {{ install_directory }}/openstackrc; {{ openstack_location }}"
 
     # Delete any images with the same name as the one we are about to upload.
     - name: Deleting the existing images in OpenStack
@@ -176,5 +173,5 @@
 
     # Add metadata to the OpenStack about the image.
     - name: Adding metadata about the image
-      shell: "{{ openstack }} image set --property file_name={{ item|basename }} --property directory={{ item|dirname }} ocp-{{ ocp_major_minor }}-{{ ('atomic' in item['path'])|ternary('atomic','rhel') }}"
+      shell: "{{ openstack }} image set --property file_name={{ item|basename }} --property directory={{ item|dirname }} ocp-{{ ocp_major_minor }}-{{ ('atomic' in item)|ternary('atomic','rhel') }}"
       with_items: "{{ files }}"

--- a/find_and_prepare_images.yml
+++ b/find_and_prepare_images.yml
@@ -6,18 +6,16 @@
     atomic_image: "{{ lookup('env', 'atomic_image') }}"
     delete_qcow2_images: true
     files: []
-    install_directory: "{{ ansible_user_dir }}/scale-ci"
     # A string path relative to the user's home directory.
     image_directory: image_builder/qcow_images
     ocp_major_minor: "{{ lookup('env', 'ocp_major_minor') | default('3.7', true) }}"
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(install_directory ~ '/virtualenv/bin/openstack', true) }}"
+    # Copy the images to this remote host.
+    remote_host: "{{ groups['openstack-server'][0] }}"
+    # Copy the images to this directory on the remote host.
+    remote_image_directory: "/home/{{ hostvars[remote_host]['ansible_user'] }}/scale-ci"
     # A string path relative to the user's home directory to the rhel image.
     rhel_image: "{{ lookup('env', 'rhel_image') }}"
-    virtualenv_directory: "{{ install_directory }}/virtualenv"
     web_root: /var/www/html
-  roles:
-    # Install the OpenStack client on this server.
-    - "openstack-client"
   tasks:
     # Get all the atomic files matching the pattern.
     - name: Searching for the ocp-{{ ocp_major_minor }} files in {{ image_directory }}/atomic
@@ -141,37 +139,30 @@
         - "{{ qcow2_files['results'] }}"
       when: item[1]['stat']['exists'] == false
 
-    # Copy the rc file to the image server.
-    - name: Copying the OpenStack rc file to the image server
-      copy:
-        src: "{{ playbook_dir }}/openstackrc"
-        dest: "{{ install_directory }}/openstackrc"
-
-    # The openstack variable includes the rc file and the path to the OpenStack client.
-    - name: Setting openstack variable to source the rc file and contain path to client
-      set_fact:
-        openstack: "source {{ install_directory }}/openstackrc; {{ openstack_location }}"
-
-    # Delete any images with the same name as the one we are about to upload.
-    - name: Deleting the existing images in OpenStack
-      shell: "{{ openstack }} image delete ocp-{{ ocp_major_minor }}-{{ item }}"
-      with_items: "{{ [ 'atomic', 'rhel' ] }}"
-      # Do not fail if there was no image to delete.
-      ignore_errors: true
-
-    # Upload the images to Glance.
-    - name: Uploading the images to OpenStack
-      # --min-disk <disk-gb>  Minimum disk size needed to boot image, in gigabytes
-      shell: "{{ openstack }} image create --disk-format qcow2 --container-format bare --file {{ web_root }}/{{ (item|splitext)[0] }}.qcow2 ocp-{{ ocp_major_minor }}-{{ ('atomic' in item)|ternary('atomic','rhel') }} --format value -c id"
+    # Get the sha256sum of the qcow2 files.
+    - name: Generating the checksum of the qcow2 files
+      stat:
+        checksum_algorithm: sha256
+        path: "{{ web_root }}/{{ (item|splitext)[0] }}.qcow2"
       with_items: "{{ files }}"
-      register: create_result
-      # Retry up to 3 times looking for a successful return code.
-      until: create_result['rc'] == 0
-      retries: 3
-      delay: 5
-      ignore_errors: yes
+      register: qcow2_files
 
-    # Add metadata to the OpenStack about the image.
-    - name: Adding metadata about the image
-      shell: "{{ openstack }} image set --property file_name={{ item|basename }} --property directory={{ item|dirname }} ocp-{{ ocp_major_minor }}-{{ ('atomic' in item)|ternary('atomic','rhel') }}"
+    # Create the image directories on the remote host.
+    - name: "Creating the image directories on {{ remote_host }}"
+      file:
+        path: "{{ remote_image_directory }}/{{ item|dirname }}"
+        state: directory
       with_items: "{{ files }}"
+      delegate_to: "{{ remote_host }}"
+
+    # Copy the images from image server to the remote host.
+    - name: "Copying the files from the image server to {{ remote_host }}"
+      get_url:
+        checksum: "sha256:{{ item[1]['stat']['checksum'] }}"
+        dest: "{{ remote_image_directory }}/{{ (item[0]|splitext)[0] }}.qcow2"
+        # http://image-server/image_buiilder/qcow_images/{atomic,rhel}/*.qcow2
+        url: "http://{{ groups['image-server'][0] }}/{{ (item[0]|splitext)[0] }}.qcow2"
+      with_together:
+        - "{{ files }}"
+        - "{{ qcow2_files['results'] }}"
+      delegate_to: "{{ remote_host }}"

--- a/openshift_on_openstack.yml
+++ b/openshift_on_openstack.yml
@@ -143,7 +143,7 @@
     # Copy the OpenStack rc file from the Ansible host to the target host.
     - name: Copying the OpenStack rc file from Ansible host to target host
       copy:
-        src: "openstackrc"
+        src: "{{ playbook_dir }}/openstackrc"
         dest: "{{ openstack_rc }}"
 
     # Add an authentication block to the end of the OSEv3 file.

--- a/reset_openstack_environment.yml
+++ b/reset_openstack_environment.yml
@@ -1,10 +1,10 @@
 ---
 - name: Steps to clean up an OpenStack environment
-  hosts: localhost
+  hosts: openstack-server
   vars:
     env_id: "{{ lookup('env', 'env_id') | default('scale-ci', true) }}"
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/openstackrc', true) }}"
+    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(('/usr/bin/openstack', true) }}"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/overcloudrc', true) }}"
 
   tasks:
     # Check for the existance of the OpenStack client.

--- a/reset_openstack_environment.yml
+++ b/reset_openstack_environment.yml
@@ -1,11 +1,10 @@
 ---
 - name: Steps to clean up an OpenStack environment
-  hosts: openstack-server
+  hosts: localhost
   vars:
     env_id: "{{ lookup('env', 'env_id') | default('scale-ci', true) }}"
-    install_directory: "{{ ansible_user_dir }}/scale-ci"
-    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(install_directory ~ '/virtualenv/bin/openstack', true) }}"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default('~/overcloudrc', true) }}"
+    openstack_location: "{{ lookup('env', 'openstack_client_path' ) | default(playbook_dir ~ '/virtualenv/bin/openstack', true) }}"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(playbook_dir ~ '/openstackrc', true) }}"
 
   tasks:
     # Check for the existance of the OpenStack client.
@@ -30,7 +29,7 @@
       shell: "{{ openstack }} stack list --format value -c ID"
       register: stacks
 
-    # The openshift installer uses a stack, try deleting that first.
+    # The OpenShift installer uses a stack, try deleting that first.
     - name: Deleting the all the stacks
       shell: "{{ openstack }} stack delete --yes --wait {{ item }}"
       with_items: "{{ stacks.stdout_lines }}"

--- a/roles/openstack-client/tasks/main.yml
+++ b/roles/openstack-client/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# Create a virtual Python environment to contain python packages.
+- name: Creating a virtual Python environment to install requirements
+  command: "virtualenv {{ virtualenv_directory }}"
+  when: virtualenv_directory is defined
+
+# Change the path to the virtual environment if necessary.
+- name: Changing the pip path to the virtual Python environment
+  set_fact:
+    pip: "{{ virtualenv_directory }}/bin/pip"
+  when: virtualenv_directory is defined
+
+# Install the Python packages using pip with the command module.
+- name: Installing the Python packages
+  # Using command module because the Ansible pip module may not be installed.
+  command: "{{ pip }} install {{ item }}"
+  with_items: "{{ packages['openstack'] }}"
+  when: virtualenv_directory is defined
+
+# Install the Python packages using pip with the command module.
+- name: Installing the Python packages in the user directory
+  # Using command module because the Ansible pip module may not be installed.
+  command: "{{ pip }} install --user {{ item }}"
+  with_items: "{{ packages['openstack'] }}"
+  when: virtualenv_directory is not defined

--- a/roles/openstack-client/vars/main.yml
+++ b/roles/openstack-client/vars/main.yml
@@ -1,0 +1,12 @@
+---
+packages:
+  Fedora:
+    - python2-virtualenv
+  CentOS:
+    - python-virtualenv
+  RedHat:
+    - python-virtualenv
+  openstack:
+    - python-openstackclient==3.11.0
+    - python-heatclient
+pip: pip

--- a/setup_remote_openstack.yml
+++ b/setup_remote_openstack.yml
@@ -1,45 +1,13 @@
 ---
-- name: Prepare a remote openstack-server to run scale-ci
+- name: Copy the overcloudrc file from the openstack-server
   hosts: openstack-server
-  vars:
-    install_directory: "{{ ansible_user_dir }}/scale-ci"
-    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(ansible_user_dir ~ '/overcloudrc', true) }}"
-    virtualenv_directory: "{{ install_directory }}/virtualenv"
-
-  pre_tasks:
-    # Delete any existing code before the role installs the prerequisites.
-    - name: Deleting any existing code on the openstack-server
-      file:
-        path: "{{ item }}"
-        state: absent
-      with_items:
-        - "{{ install_directory }}"
-        - "{{ ansible_user_dir }}/.ssh/known_hosts"
-
-  roles:
-    # Install general prerequisites for OpenStack and Ansible.
-    - general-prerequisites
-
   tasks:
-    # Copy the public key so it can be used to create the OpenStack keypair.
-    - name: Copying the public key to the openstack-server
-      copy:
-        src: "{{ ansible_public_key_file }}"
-        dest: "{{ install_directory }}/key.public"
-
-    # Copy the private key so it can be used to access OpenStack VMs.
-    - name: Copying the private key to the openstack-server
-      copy:
-        src: "{{ ansible_private_key_file }}"
-        dest: "{{ install_directory }}/key.private"
-        mode: 0600
-
     # Copy the OpenStack rc file from the OpenStack server.
     - name: Fetching the OpenStack rc file from the openstack-server
       fetch:
         src: "{{ openstack_rc }}"
         flat: yes
-        dest: "openstackrc"
+        dest: "{{ playbook_dir }}/openstackrc"
 
 # import_playbook to start the openstack setup.
 - include: setup_openstack_environment.yml

--- a/setup_remote_openstack.yml
+++ b/setup_remote_openstack.yml
@@ -1,7 +1,32 @@
 ---
 - name: Copy the overcloudrc file from the openstack-server
   hosts: openstack-server
+  vars:
+    install_directory: "{{ ansible_user_dir }}/scale-ci"
+    openstack_rc: "{{ lookup('env', 'openstack_rc_path') | default(ansible_user_dir ~ '/overcloudrc', true) }}"
+  pre_tasks:
+    # Delete any existing code before the role installs the prerequisites.
+    - name: Deleting any existing code on the openstack-server
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - "{{ install_directory }}"
+        - "{{ ansible_user_dir }}/.ssh/known_hosts"
   tasks:
+    # Copy the public key so it can be used to create the OpenStack keypair.
+    - name: Copying the public key to openstack-server
+      copy:
+        src: "{{ ansible_public_key_file }}"
+        dest: "{{ install_directory }}/key.public"
+
+    # Copy the private key so it can be used to access OpenStack VMs.
+    - name: Copying the private key to openstack-server
+      copy:
+        src: "{{ ansible_private_key_file }}"
+        dest: "{{ install_directory }}/key.private"
+        mode: 0600
+
     # Copy the OpenStack rc file from the OpenStack server.
     - name: Fetching the OpenStack rc file from the openstack-server
       fetch:


### PR DESCRIPTION
Sai was concerned about installing stuff on the undercloud. That caused me to refactor the work to not use the undercloud at all, but the OpenStack services are not available on the public network. So this turned out to be a bad thing.

This change is going to use the existing openstack client that is installed on the undercloud without installing anything on the openstack-server.